### PR TITLE
Switch to handlePayments for payments

### DIFF
--- a/src/lib/functions/sendBoost.js
+++ b/src/lib/functions/sendBoost.js
@@ -47,7 +47,7 @@ export default async function sendBoost({ block, satAmount, boostagram, senderNa
 	}
 
 	console.log(payments);
-	let res = await fetch(remoteServer + '/api/alby/boost', {
+	let res = await fetch(remoteServer + '/api/alby/handlePayments', {
 		method: 'POST',
 		credentials: 'include',
 		headers: { 'Content-Type': 'application/json' },
@@ -69,6 +69,7 @@ export default async function sendBoost({ block, satAmount, boostagram, senderNa
 		}
 
 		let payload = {
+			type: dest.type,
 			destination: dest.address,
 			amount: amount,
 			customRecords: customRecords

--- a/src/lib/functions/sendBoostRemote.js
+++ b/src/lib/functions/sendBoostRemote.js
@@ -23,7 +23,7 @@ export default async function sendBoost({ item, satAmount, boostagram, senderNam
 		}
 	}
 
-	let res = await fetch(remoteServer + '/api/alby/boost', {
+	let res = await fetch(remoteServer + '/api/alby/handlePayments', {
 		method: 'POST',
 		credentials: 'include',
 		headers: { 'Content-Type': 'application/json' },
@@ -43,6 +43,7 @@ export default async function sendBoost({ item, satAmount, boostagram, senderNam
 		}
 
 		let payload = {
+			type: dest.type,
 			destination: dest.address,
 			amount: amount,
 			customRecords: customRecords


### PR DESCRIPTION
Switched to handlePayments to handle lnaddress payments. The current boosts one only seems to handle keysend.